### PR TITLE
Escape using JSON.stringify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-plugin-text",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-plugin-text",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "text file loader asset type",
   "main": "src/index.js",
   "author": "janouma",

--- a/src/asset.js
+++ b/src/asset.js
@@ -10,15 +10,13 @@ module.exports = class TextAsset extends Asset {
   }
 
   generate () {
-    const content = this.contents.replace(/`/g, '\\`')
-      .replace(/\$(?=\{.*?\})/g, '\\$')
-
+    const content = JSON.stringify(this.contents);
     log.debug({ loaded: this.name })
-    log.trace({content})
+    log.trace({ content })
 
     return [{
       type: 'js',
-      value: `module.exports = \`${content}\``
+      value: `module.exports = ${content}`,
     }]
   }
 }


### PR DESCRIPTION
I had a file with `\+` in the contents. When imported, the `\` was lost because the `\` was not properly escaped. Rather than fully implementing proper escape behaviour, `JSON.stringify` provides it for free. 